### PR TITLE
Larger screen size on VitaTV for PS1 games in normal mode

### DIFF
--- a/user/menu.c
+++ b/user/menu.c
@@ -385,7 +385,12 @@ void getPopsScreenSize(float *scale_x, float *scale_y) {
 
   // PSTV scale fix
   if (sceKernelIsPSVitaTV()) {
-    (*scale_y) *= 0.845f;
+    if (config.screen_mode == SCREEN_MODE_NORMAL) {
+      (*scale_y) = 1.0f;
+      (*scale_x) = 1.0f / 0.845f;
+    } else {
+      (*scale_y) *= 0.845f;
+    }
   }
 }
 


### PR DESCRIPTION
The top and bottom black borders of PS1 games on VitaTV
in normal mode are eliminated by increasing the width of
the image instead of decreasing the height. The aspect
ratio is still corrected, but the resulting image is
slightly larger.