### PR TITLE
Larger vertical size on VitaTV for PS1 games in full mode

### DIFF
--- a/user/menu.c
+++ b/user/menu.c
@@ -385,11 +385,21 @@ void getPopsScreenSize(float *scale_x, float *scale_y) {
 
   // PSTV scale fix
   if (sceKernelIsPSVitaTV()) {
-    if (config.screen_mode == SCREEN_MODE_NORMAL) {
-      (*scale_y) = 1.0f;
-      (*scale_x) = 1.0f / 0.845f;
-    } else {
-      (*scale_y) *= 0.845f;
+    switch (config.screen_mode) {
+      case SCREEN_MODE_NORMAL:
+        *scale_y = 1.0f;
+        *scale_x = 1.0f / 0.845f;
+        break;
+
+      case SCREEN_MODE_FULL:
+        *scale_y = 1.0f;
+        break;  
+
+      case SCREEN_MODE_ZOOM:
+      case SCREEN_MODE_ORIGINAL:
+      default:
+        (*scale_y) *= 0.845f;
+        break;
     }
   }
 }


### PR DESCRIPTION
This patch improves VITATV PS1 full mode by removing the black bars on top and bottom. Since full mode should fill out the screen both horizontally and vertically, the height does not have to be reduced in this case.