### PR TITLE
Enabled MSAA 4x.

### DIFF
--- a/user/menu.c
+++ b/user/menu.c
@@ -386,7 +386,7 @@ int AdrenalineDraw(SceSize args, void *argp) {
   sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_DATE_FORMAT, &date_format);
   sceAppUtilSystemParamGetInt(SCE_SYSTEM_PARAM_ID_TIME_FORMAT, &time_format);
 
-  vita2d_init();
+  vita2d_init_with_msaa(0x100000, SCE_GXM_MULTISAMPLE_4X);
   font = vita2d_load_default_pgf();
 
   vita2d_texture *psp_tex = vita2d_create_empty_texture(PSP_SCREEN_LINE, PSP_SCREEN_HEIGHT);


### PR DESCRIPTION
Untested, requires updated libvita2d fbo fork from frangarcj (i've already pushed required changes to add MSAA support to it).