### PR TITLE
Fix compilation

### DIFF
--- a/cef/vshctrl/isofs_driver/isofs_driver.c
+++ b/cef/vshctrl/isofs_driver/isofs_driver.c
@@ -21,7 +21,7 @@ int IsofsReadSectors(int lba, int nsectors, void *buf) {
 	return Umd9660ReadSectors2(lba, nsectors, buf);
 }
 
-inline int SizeToSectors(int size) {
+static inline int SizeToSectors(int size) {
 	int len = size / SECTOR_SIZE;
 	if ((size % SECTOR_SIZE) != 0) len++;
 	return len;

--- a/vsh/CMakeLists.txt
+++ b/vsh/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(adrenaline_vsh
 )
 
 target_link_libraries(adrenaline_vsh
-  taiHEN_stub
+  taihen_stub
   SceAppMgr_stub
   SceLsdb_stub_weak
 )


### PR DESCRIPTION
Lowercase makes a difference :smile: 

Also the inlined function could not be located by the compiler.

It will now compile, but on recent VitaSDK installations, my `adrenaline_user` module turns out to be some 10KB lighter than what it should and it crashes immediately on startup :cry:. Also, I get some weird warnings like:

```
make[1]: Entering directory '/home/andre/Development/andrebrait.github.com/Adrenaline/cef/systemctrl'
psp-gcc -I/usr/local/pspdev/psp/sdk/include/libc -I../include -I. -I/usr/local/pspdev/psp/sdk/include -O2 -Os -G0 -Wall -fshort-wchar -fno-pic -mno-check-zero-division -D_PSP_FW_VERSION=150   -c -o main.o main.c
main.c: In function ‘OnSystemStatusIdle’:
main.c:331:3: warning: implicit declaration of function ‘sceDisplaySetFrameBuf661’; did you mean ‘sceDisplaySetFrameBuf’? [-Wimplicit-function-declaratio]
  331 |   sceDisplaySetFrameBuf661((void *)0x0A000000, PSP_SCREEN_LINE, PSP_DISPLAY_PIXEL_FORMAT_8888, PSP_DISPLAY_SETBUF_NEXTFRAME);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
      |   sceDisplaySetFrameBuf

make[1]: Entering directory '/home/andre/Development/andrebrait.github.com/Adrenaline/cef/vshctrl'
psp-gcc -I/usr/local/pspdev/psp/sdk/include/libc -I../include -I. -I/usr/local/pspdev/psp/sdk/include -O2 -Os -G0 -Wall -fshort-wchar -fno-pic -mno-check-zero-division -D_PSP_FW_VERSION=150   -c -o main.o main.c
main.c: In function ‘MakeSyscallStub’:
main.c:700:20: warning: implicit declaration of function ‘sceKernelQuerySystemCall’; did you mean ‘sceKernelGetSystemTime’? [-Wimplicit-function-declaration]
  700 |  _sw(0x0000000C | (sceKernelQuerySystemCall(function) << 6), stub + 4);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~
      |                    sceKernelGetSystemTime
```
