### PR TITLE
Compile under new VitaSDK

### DIFF
--- a/user/CMakeLists.txt
+++ b/user/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(adrenaline_user
   SceKernelThreadMgr_stub
   SceLibKernel_stub
   SceMtpIfDriver_stub
+  SceNet_stub_weak
   ScePgf_stub_weak
   ScePower_stub
   SceProcessmgr_stub

--- a/user/utils.c
+++ b/user/utils.c
@@ -45,11 +45,24 @@ void _init_vita_reent(void);
 void _init_vita_malloc(void);
 void _init_vita_io(void);
 
+void _free_vita_heap(void);
+void _free_vita_reent(void);
+void _free_vita_malloc(void);
+void _free_vita_io(void);
+
 void _init_vita_newlib(void) {
   _init_vita_heap();
   _init_vita_reent();
   _init_vita_malloc();
   _init_vita_io();
+}
+
+void _free_vita_newlib(void)
+{
+  _free_vita_io();
+  _free_vita_malloc();
+  _free_vita_reent();
+  _free_vita_heap();
 }
 
 int debugPrintf(char *text, ...) {

--- a/user/utils.h
+++ b/user/utils.h
@@ -56,6 +56,7 @@ extern Pad old_pad, current_pad, pressed_pad, released_pad, hold_pad, hold2_pad;
 extern Pad hold_count, hold2_count;
 
 void _init_vita_newlib(void);
+void _free_vita_newlib(void);
 
 int debugPrintf(char *text, ...);
 int ReadFile(char *file, void *buf, int size);

--- a/vsh/CMakeLists.txt
+++ b/vsh/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(adrenaline_vsh
   taihen_stub
   SceAppMgr_stub
   SceLsdb_stub_weak
+  SceNet_stub_weak
 )
 
 vita_create_self(adrenaline_vsh.suprx adrenaline_vsh CONFIG exports.yml UNSAFE)

--- a/vsh/utils.c
+++ b/vsh/utils.c
@@ -24,6 +24,19 @@
 #include <stdarg.h>
 #include <string.h>
 
+void _free_vita_heap(void);
+void _free_vita_reent(void);
+void _free_vita_malloc(void);
+void _free_vita_io(void);
+
+void _free_vita_newlib(void)
+{
+  _free_vita_io();
+  _free_vita_malloc();
+  _free_vita_reent();
+  _free_vita_heap();
+}
+
 int debugPrintf(char *text, ...) {
   va_list list;
   char string[512];

--- a/vsh/utils.h
+++ b/vsh/utils.h
@@ -19,6 +19,8 @@
 #ifndef __UTILS_H__
 #define __UTILS_H__
 
+void _free_vita_newlib(void);
+
 int debugPrintf(char *text, ...);
 int ReadFile(char *file, void *buf, int size);
 int WriteFile(char *file, void *buf, int size);


### PR DESCRIPTION
It seems there were some changes on newlib or their work on libc that caused the build to break.

Without this, compilation breaks with 

```
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: /usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/lib/libc.a(lib_a-syscalls.o): in function `_exit':
syscalls.c:(.text._exit+0x4): undefined reference to `_free_vita_newlib'
```