### PR TITLE
Fix doubletap on first boot.

### DIFF
--- a/bubble/main.c
+++ b/bubble/main.c
@@ -207,5 +207,7 @@ int main() {
 		while (1);
 	}
 
+	// restart application
+	sceAppMgrLoadExec("ux0:app/" ADRENALINE_TITLEID "/eboot.bin", NULL, NULL);
 	return 0;
 }


### PR DESCRIPTION
sceAppMgrLoadExec is effectively the same as just restarting the app, but without any animation it resolves all kernel imports/exports and re-creates the process, running it at the end should work basically the same as the user launching the app a 2nd time.